### PR TITLE
[TT-9720] Removed Refit dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Total tests: 42
 
 ## Changes
 
+### v4.1.0
+
+- chore: removed Refit dependency
+
 ### v4.0.0
 
 - **breaking change**: moved `AutosuggestInputType` and `Request<T>` to `what3words.dotnet.wrapper.request` namespace

--- a/sample/sample.Console/Arguments.cs
+++ b/sample/sample.Console/Arguments.cs
@@ -1,46 +1,41 @@
 /**
  * A simple utility class to parse command line arguments.
  */
+using System;
+
 namespace sample.Console.Utils
 {
-    using System;
     public class Arguments
     {
-        private string[] _args;
-        private string _command;
+        private readonly string[] args;
+        private readonly string command;
         public Arguments(string[] args)
         {
-            _command = this.ResolveCommand(args);
-            _args = args;
+            command = ResolveCommand(args);
+            this.args = args;
         }
 
-        private string ResolveCommand(string[] args)
+        private static string ResolveCommand(string[] args)
         {
-            if (string.IsNullOrEmpty(args[0]) || args[0].StartsWith("--"))
-            {
-                if (args[0].StartsWith("--") && args[0].Equals("--help"))
-                {
-                    return "help";
-                }
-                throw new InvalidOperationException("Invalid command provided.");
-            }
-            return args[0];
+            return string.IsNullOrEmpty(args[0]) || args[0].StartsWith("--", StringComparison.Ordinal)
+                ? args[0].StartsWith("--", StringComparison.Ordinal) && args[0].Equals("--help", StringComparison.OrdinalIgnoreCase)
+                    ? "help"
+                    : throw new InvalidOperationException("Invalid command provided.")
+                : args[0];
         }
 
         public string GetArgument(string name)
         {
-            if (_args == null || _args.Length == 0)
+            if (args == null || args.Length == 0)
             {
                 throw new InvalidOperationException("No arguments provided.");
             }
-            int index = Array.IndexOf(_args, name);
-            if (index >= 0 && index + 1 < _args.Length && !string.IsNullOrEmpty(_args[index + 1]) && !_args[index + 1].StartsWith("--"))
-            {
-                return _args[index + 1];
-            }
-            throw new InvalidOperationException($"{name} is missing or not provided.");
+            var index = Array.IndexOf(args, name);
+            return index >= 0 && index + 1 < args.Length && !string.IsNullOrEmpty(args[index + 1]) && !args[index + 1].StartsWith("--", StringComparison.Ordinal)
+                ? args[index + 1]
+                : throw new InvalidOperationException($"{name} is missing or not provided.");
         }
 
-        public string GetCommand() => _command;
+        public string GetCommand() => command;
     }
 }

--- a/sample/sample.Console/Program.cs
+++ b/sample/sample.Console/Program.cs
@@ -2,35 +2,35 @@
  * Simple console application using the what3words-dotnet-wrapper.
  */
 
+using sample.Console.Utils;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using what3words.dotnet.wrapper;
 using what3words.dotnet.wrapper.models;
-using what3words.dotnet.wrapper.response;
-using System.Linq;
-using System.Globalization;
+using what3words.dotnet.wrapper.request;
 
 namespace sample.Console
 {
-    using System;
-    using Utils;
-
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             try
             {
                 var arguments = new Arguments(args);
-                if (arguments.GetCommand().Equals("help"))
+                if (arguments.GetCommand().Equals("help", System.StringComparison.Ordinal))
                 {
                     PrintUsage();
                     return;
                 }
-                string apiKey = arguments.GetArgument("--api-key");
+                var apiKey = arguments.GetArgument("--api-key");
                 if (apiKey != null)
                 {
-                    What3WordsV3 api = new What3WordsV3(apiKey);
+                    var api = new What3WordsV3(apiKey);
                     switch (arguments.GetCommand())
                     {
+
                         case "convert-to-coordinates":
                             ConvertToCoordinates(api, arguments);
                             break;
@@ -40,63 +40,90 @@ namespace sample.Console
                         case "autosuggest":
                             AutoSuggest(api, arguments);
                             break;
+                        case "autosuggest-with-coordinates":
+                            AutosuggestWithCoordinates(api, arguments);
+                            break;
+                        case "autosuggest-selection":
+                            AutoSuggestSelection(api, arguments);
+                            break;
+                        case "available-languages":
+                            AvailableLanguages(api);
+                            break;
+                        case "grid-section":
+                            GridSection(api, arguments);
+                            break;
+                        case "is-possible-3wa":
+                            IsPossible3wa(api, arguments);
+                            break;
+                        case "find-possible-3wa":
+                            FindPossible3wa(api, arguments);
+                            break;
+                        case "is-valid-3wa":
+                            IsValid3wa(api, arguments);
+                            break;
                         default:
-                            Console.WriteLine("Command is not supported.");
+                            System.Console.WriteLine("Command is not supported.");
                             PrintUsage();
                             break;
                     }
                 }
             }
-            catch (Exception error)
+            catch (System.Exception error)
             {
-                Console.WriteLine("Something went wrong, " + error.Message);
+                System.Console.WriteLine("Something went wrong, " + error.Message);
                 PrintUsage();
             }
         }
 
-        static void PrintUsage()
+        private static void PrintUsage()
         {
-            Console.WriteLine("Usage: <command> [options]");
-            Console.WriteLine("Required parameters:");
-            Console.WriteLine("  --api-key <key>");
-            Console.WriteLine("Commands:");
-            Console.WriteLine("  convert-to-coordinates --3wa <3 word address>");
-            Console.WriteLine("  convert-to-3wa --lat <latitude> --lng <longitude>");
-            Console.WriteLine("  autosuggest --input <input>");
+            System.Console.WriteLine("Usage: <command> [options]");
+            System.Console.WriteLine("Required parameters:");
+            System.Console.WriteLine("  --api-key <key>");
+            System.Console.WriteLine("Commands:");
+            System.Console.WriteLine("  convert-to-coordinates --3wa <3 word address>");
+            System.Console.WriteLine("  convert-to-3wa --lat <latitude> --lng <longitude>");
+            System.Console.WriteLine("  grid-section --sw-lat <latitude> --sw-lng <longitude> --ne-lat <latitude> --ne-lng <longitude>");
+            System.Console.WriteLine("  autosuggest --input <input>");
+            System.Console.WriteLine("  autosuggest-with-coordinates --input <input>");
+            System.Console.WriteLine("  autosuggest-selection --raw-input <input> --source-api <source-api> --words <words> --rank <rank>");
+            System.Console.WriteLine("  available-languages");
+            System.Console.WriteLine("  is-possible-3wa --words <words>");
+            System.Console.WriteLine("  find-possible-3wa --words <words>");
+            System.Console.WriteLine("  is-valid-3wa --words <words>");
         }
 
-        static void ConvertToCoordinates(What3WordsV3 api, Arguments arg)
+        private static void ConvertToCoordinates(What3WordsV3 api, Arguments arg)
         {
             var threeWords = arg.GetArgument("--3wa");
             var result = api.ConvertToCoordinates(threeWords).RequestAsync().Result;
             if (result.IsSuccessful)
             {
-                Console.WriteLine("Coordinates: " + result.Data.Coordinates.Lat + ", " + result.Data.Coordinates.Lng);
+                System.Console.WriteLine("Coordinates: " + result.Data.Coordinates.Lat + ", " + result.Data.Coordinates.Lng);
             }
             else
             {
-                Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
             }
         }
 
-        static void ConvertTo3WA(What3WordsV3 api, Arguments arg)
+        private static void ConvertTo3WA(What3WordsV3 api, Arguments arg)
         {
-            double latitude, longitude;
-            var lat = double.TryParse(arg.GetArgument("--lat"), NumberStyles.Any, CultureInfo.InvariantCulture, out latitude) ? latitude : 0.0;
-            var lng = double.TryParse(arg.GetArgument("--lng"), NumberStyles.Any, CultureInfo.InvariantCulture, out longitude) ? longitude : 0.0;
+            var lat = double.TryParse(arg.GetArgument("--lat"), NumberStyles.Any, CultureInfo.InvariantCulture, out var latitude) ? latitude : 0.0;
+            var lng = double.TryParse(arg.GetArgument("--lng"), NumberStyles.Any, CultureInfo.InvariantCulture, out var longitude) ? longitude : 0.0;
             var coordinates = new Coordinates(lat, lng);
             var result = api.ConvertTo3WA(coordinates).RequestAsync().Result;
             if (result.IsSuccessful)
             {
-                Console.WriteLine($"3 word address: https://w3w.co/{result.Data.Words}");
+                System.Console.WriteLine($"3 word address: https://w3w.co/{result.Data.Words}");
             }
             else
             {
-                Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
             }
         }
 
-        static void AutoSuggest(What3WordsV3 api, Arguments arg)
+        private static void AutoSuggest(What3WordsV3 api, Arguments arg)
         {
             var input = arg.GetArgument("--input");
             var result = api.Autosuggest(input).RequestAsync().Result;
@@ -104,16 +131,122 @@ namespace sample.Console
             {
                 if (result.Data.Suggestions.Count > 0)
                 {
-                    Console.WriteLine("Suggestions: " + string.Join(", ", result.Data.Suggestions.Select(x => $"https://w3w.co/{x.Words}")));
+                    System.Console.WriteLine("Suggestions: " + string.Join(", ", result.Data.Suggestions.Select(x => $"https://w3w.co/{x.Words}")));
                 }
                 else
                 {
-                    Console.WriteLine("No suggestions found.");
+                    System.Console.WriteLine("No suggestions found.");
                 }
             }
             else
             {
-                Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+            }
+        }
+
+        private static void AutoSuggestSelection(What3WordsV3 api, Arguments arg)
+        {
+            var input = arg.GetArgument("--raw-input");
+            var sourceApi = arg.GetArgument("--source-api");
+            var words = arg.GetArgument("--words");
+            var rank = int.TryParse(arg.GetArgument("--rank"), out var r) ? r : 0;
+            var options = new AutosuggestOptions();
+            var result = api.AutosuggestSelection(input, sourceApi, words, rank, options).RequestAsync().Result;
+            if (result.IsSuccessful)
+            {
+                System.Console.WriteLine($"Suggestion for {words} selected");
+            }
+            else
+            {
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+            }
+        }
+
+        private static void AvailableLanguages(What3WordsV3 api)
+        {
+            var result = api.AvailableLanguages().RequestAsync().Result;
+            if (result.IsSuccessful)
+            {
+                System.Console.WriteLine("Languages: " + string.Join(", ", result.Data.Languages.Select(x => $"{x.Name} [{x.Code}]")));
+            }
+            else
+            {
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+            }
+        }
+
+        private static void GridSection(What3WordsV3 api, Arguments arg)
+        {
+            var southWestLat = arg.GetArgument("--sw-lat");
+            var southWestLng = arg.GetArgument("--sw-lng");
+            var northEastLat = arg.GetArgument("--ne-lat");
+            var northEastLng = arg.GetArgument("--ne-lng");
+            var southWest = new Coordinates(double.Parse(southWestLat, CultureInfo.InvariantCulture), double.Parse(southWestLng, CultureInfo.InvariantCulture));
+            var northEast = new Coordinates(double.Parse(northEastLat, CultureInfo.InvariantCulture), double.Parse(northEastLng, CultureInfo.InvariantCulture));
+            var result = api.GridSection(southWest, northEast).RequestAsync().Result;
+            if (result.IsSuccessful)
+            {
+                System.Console.WriteLine("Grid section: " + string.Join(", ", result.Data.Lines.Select(x => x.Start.Lat + ", " + x.Start.Lng + " - " + x.End.Lat + ", " + x.End.Lng)));
+            }
+            else
+            {
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+            }
+        }
+
+        private static void AutosuggestWithCoordinates(What3WordsV3 api, Arguments arg)
+        {
+            var input = arg.GetArgument("--input");
+            var result = api.AutosuggestWithCoordinates(input).RequestAsync().Result;
+            if (result.IsSuccessful)
+            {
+                System.Console.WriteLine("Suggestions: " + string.Join(", ", result.Data.Suggestions.Select(x => x.Words + " (" + x.Coordinates.Lat + ", " + x.Coordinates.Lng + ")")));
+            }
+            else
+            {
+                System.Console.WriteLine(result.Error.Code + " - " + result.Error.Message);
+            }
+        }
+
+        private static void IsPossible3wa(What3WordsV3 api, Arguments arg)
+        {
+            var words = arg.GetArgument("--words");
+            var result = api.IsPossible3wa(words);
+            if (result)
+            {
+                System.Console.WriteLine($"\"{words}\" is possibly a 3 word address");
+            }
+            else
+            {
+                System.Console.WriteLine($"\"{words}\" is not a possible 3 word address");
+            }
+        }
+
+        private static void FindPossible3wa(What3WordsV3 api, Arguments arg)
+        {
+            var words = arg.GetArgument("--words");
+            var result = api.FindPossible3wa(words);
+            if (result.Any())
+            {
+                System.Console.WriteLine("Possible 3 word addresses: " + string.Join(", ", result));
+            }
+            else
+            {
+                System.Console.WriteLine("No possible 3 word addresses found.");
+            }
+        }
+
+        private static void IsValid3wa(What3WordsV3 api, Arguments arg)
+        {
+            var words = arg.GetArgument("--words");
+            var result = api.IsValid3wa(words);
+            if (result)
+            {
+                System.Console.WriteLine($"\"{words}\" is a valid 3 word address");
+            }
+            else
+            {
+                System.Console.WriteLine($"\"{words}\" is not a valid 3 word address");
             }
         }
     }

--- a/sample/sample.Console/sample.Console.csproj
+++ b/sample/sample.Console/sample.Console.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\..\what3words.dotnet.wrapper\what3words.dotnet.wrapper.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
 </Project>

--- a/what3words.dotnet.sln
+++ b/what3words.dotnet.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sample.Console", "sample\sample.Console\sample.Console.csproj", "{F338C03F-A651-484D-AFEF-AC0F225E0819}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,30 @@ Global
 		{E949A39D-C622-46F4-A26E-9120CD54A5E7}.Release|x64.Build.0 = Release|Any CPU
 		{E949A39D-C622-46F4-A26E-9120CD54A5E7}.Release|x86.ActiveCfg = Release|Any CPU
 		{E949A39D-C622-46F4-A26E-9120CD54A5E7}.Release|x86.Build.0 = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|x64.Build.0 = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Debug|x86.Build.0 = Debug|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|ARM.Build.0 = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|iPhone.Build.0 = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|x64.ActiveCfg = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|x64.Build.0 = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|x86.ActiveCfg = Release|Any CPU
+		{F338C03F-A651-484D-AFEF-AC0F225E0819}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/what3words.dotnet.wrapper.utests/Autosuggest.cs
+++ b/what3words.dotnet.wrapper.utests/Autosuggest.cs
@@ -1,19 +1,18 @@
-using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using what3words.dotnet.wrapper.models;
 using what3words.dotnet.wrapper.request;
 using what3words.dotnet.wrapper.response;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
     public class Autosuggest
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public Autosuggest()
         {

--- a/what3words.dotnet.wrapper.utests/AutosuggestWithCoordinates.cs
+++ b/what3words.dotnet.wrapper.utests/AutosuggestWithCoordinates.cs
@@ -1,15 +1,15 @@
-using Xunit;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using what3words.dotnet.wrapper.models;
 using what3words.dotnet.wrapper.request;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
     public class AutosuggestWithCoordinates
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public AutosuggestWithCoordinates()
         {

--- a/what3words.dotnet.wrapper.utests/AvailableLanguages.cs
+++ b/what3words.dotnet.wrapper.utests/AvailableLanguages.cs
@@ -1,12 +1,12 @@
-using Xunit;
 using System;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
     public class AvailableLanguages
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public AvailableLanguages()
         {

--- a/what3words.dotnet.wrapper.utests/ConvertTo3WA.cs
+++ b/what3words.dotnet.wrapper.utests/ConvertTo3WA.cs
@@ -1,16 +1,16 @@
-using Xunit;
 using System;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using what3words.dotnet.wrapper.models;
 using what3words.dotnet.wrapper.response;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
     public class ConvertTo3WA
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public ConvertTo3WA()
         {

--- a/what3words.dotnet.wrapper.utests/ConvertToCoordinates.cs
+++ b/what3words.dotnet.wrapper.utests/ConvertToCoordinates.cs
@@ -1,14 +1,14 @@
-using Xunit;
 using System;
 using System.Threading.Tasks;
 using what3words.dotnet.wrapper.response;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
 
     public class ConvertToCoordinates
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public ConvertToCoordinates()
         {

--- a/what3words.dotnet.wrapper.utests/GridSection.cs
+++ b/what3words.dotnet.wrapper.utests/GridSection.cs
@@ -1,14 +1,14 @@
-using Xunit;
 using System;
 using System.Threading.Tasks;
 using what3words.dotnet.wrapper.models;
 using what3words.dotnet.wrapper.response;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
     public class GridSection
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public GridSection()
         {

--- a/what3words.dotnet.wrapper.utests/Validate3wa.cs
+++ b/what3words.dotnet.wrapper.utests/Validate3wa.cs
@@ -1,12 +1,12 @@
-using Xunit;
 using System;
 using System.Linq;
+using Xunit;
 
 namespace what3words.dotnet.wrapper.utests
 {
     public class Validate3wa
     {
-        private What3WordsV3 api;
+        private readonly What3WordsV3 api;
 
         public Validate3wa()
         {

--- a/what3words.dotnet.wrapper/What3WordsV3.cs
+++ b/what3words.dotnet.wrapper/What3WordsV3.cs
@@ -1,5 +1,4 @@
-﻿using Refit;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -48,7 +47,7 @@ namespace what3words.dotnet.wrapper
         {
             var httpClient = new HttpClient
             {
-                BaseAddress = new Uri(endpoint.TrimEnd('/') ?? DEFAULT_ENDPOINT)
+                BaseAddress = new Uri(endpoint.TrimEnd('/') + '/' ?? DEFAULT_ENDPOINT)
             };
             httpClient.DefaultRequestHeaders.Add(W3W_WRAPPER, GetUserAgent());
             httpClient.DefaultRequestHeaders.Add(HEADER_WHAT3WORDS_API_KEY, apiKey);
@@ -60,14 +59,13 @@ namespace what3words.dotnet.wrapper
                     httpClient.DefaultRequestHeaders.Add(item.Key, item.Value);
                 }
             }
-
-            Request = RestService.For<IW3WRequests>(httpClient);
+            Request = new W3WRequests(httpClient);
         }
 
         private string GetUserAgent()
         {
-            return "what3words-dotNet/" + (GetType().Assembly.GetName().Version.ToString()) + " ("
-                + (Environment.OSVersion) + ")";
+            return "what3words-dotNet/" + GetType().Assembly.GetName().Version.ToString() + " ("
+                + Environment.OSVersion + ")";
         }
 
         /**

--- a/what3words.dotnet.wrapper/exceptions/ApiException.cs
+++ b/what3words.dotnet.wrapper/exceptions/ApiException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace what3words.dotnet.wrapper.exceptions
+{
+    internal class ApiException<T> : Exception
+    {
+        public readonly T Error;
+
+        public ApiException(string message, T error) : base(message)
+        {
+            Error = error;
+        }
+    }
+}

--- a/what3words.dotnet.wrapper/models/Coordinates.cs
+++ b/what3words.dotnet.wrapper/models/Coordinates.cs
@@ -3,17 +3,16 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class Coordinates
     {
+        public double Lng { get; set; }
+        public double Lat { get; set; }
         public Coordinates()
         {
         }
 
         public Coordinates(double lat, double lng)
         {
-            this.Lat = lat;
-            this.Lng = lng;
+            Lat = lat;
+            Lng = lng;
         }
-
-        public double Lng { get; set; }
-        public double Lat { get; set; }
     }
 }

--- a/what3words.dotnet.wrapper/request/AutosuggestOptions.cs
+++ b/what3words.dotnet.wrapper/request/AutosuggestOptions.cs
@@ -1,41 +1,40 @@
-﻿using Refit;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using what3words.dotnet.wrapper.models;
 
 namespace what3words.dotnet.wrapper.request
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-    public class AutosuggestOptions
+    public class AutosuggestOptions : URLQueryable
     {
-        [AliasAs("n-results")]
+        [QueryString("n-results")]
         public string NResults { get; private set; }
 
-        [AliasAs("focus")]
+        [QueryString("focus")]
         public string Focus { get; private set; }
 
-        [AliasAs("n-focus-results")]
+        [QueryString("n-focus-results")]
         public string NFocusResults { get; private set; }
 
-        [AliasAs("clip-to-country")]
+        [QueryString("clip-to-country")]
         public string ClipToCountry { get; private set; }
 
-        [AliasAs("clip-to-bounding-box")]
+        [QueryString("clip-to-bounding-box")]
         public string ClipToBoundingBox { get; private set; }
 
-        [AliasAs("clip-to-circle")]
+        [QueryString("clip-to-circle")]
         public string ClipToCircle { get; private set; }
 
-        [AliasAs("clip-to-polygon")]
+        [QueryString("clip-to-polygon")]
         public string ClipToPolygon { get; private set; }
 
-        [AliasAs("input-type")]
+        [QueryString("input-type")]
         public string InputType { get; private set; }
 
-        [AliasAs("prefer-land")]
+        [QueryString("prefer-land")]
         public string PreferLand { get; private set; }
 
-        [AliasAs("language")]
+        [QueryString("language")]
         public string Language { get; private set; }
 
         /**

--- a/what3words.dotnet.wrapper/request/AutosuggestSelectionRequest.cs
+++ b/what3words.dotnet.wrapper/request/AutosuggestSelectionRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using what3words.dotnet.wrapper.exceptions;
 using what3words.dotnet.wrapper.response;
 
 namespace what3words.dotnet.wrapper.request
@@ -31,28 +32,19 @@ namespace what3words.dotnet.wrapper.request
                 await _api.Request.AutoSuggestSelection(_rawInput, _selection, _rank, _sourceApi, _options);
                 return new APIResponse();
             }
-            catch (Refit.ApiException e)
+            catch (ApiException<APIError> e)
             {
-                var apiException = await e.GetContentAsAsync<ApiException>();
-                if (apiException != null)
+                return new APIResponse(new APIError
                 {
-                    return new APIResponse(apiException.Error);
-                }
-                else
-                {
-                    var error = new APIError
-                    {
-                        Code = What3WordsError.UnknownError.ToString(),
-                        Message = e.Message
-                    };
-                    return new APIResponse(error);
-                }
+                    Code = e.Error.Code,
+                    Message = e.Error.Message
+                });
             }
             catch (Exception e)
             {
                 var error = new APIError
                 {
-                    Code = What3WordsError.NetworkError.ToString(),
+                    Code = What3WordsError.UnknownError.ToString(),
                     Message = e.Message
                 };
                 return new APIResponse(error);

--- a/what3words.dotnet.wrapper/request/ConvertTo3WARequest.cs
+++ b/what3words.dotnet.wrapper/request/ConvertTo3WARequest.cs
@@ -1,18 +1,16 @@
-﻿using Refit;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Threading.Tasks;
 using what3words.dotnet.wrapper.models;
-
 namespace what3words.dotnet.wrapper.request
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class ConvertTo3WARequest : Request<Address>
     {
-        public class ConvertTo3WAOptions
+        public class ConvertTo3WAOptions : URLQueryable
         {
-            [AliasAs("coordinates")]
+            [QueryString("coordinates")]
             public string Coordinates { get; set; }
-            [AliasAs("language")]
+            [QueryString("language")]
             public string Language { get; set; }
         }
 

--- a/what3words.dotnet.wrapper/response/APIError.cs
+++ b/what3words.dotnet.wrapper/response/APIError.cs
@@ -12,7 +12,7 @@ namespace what3words.dotnet.wrapper.response
         {
             get
             {
-                Enum.TryParse(Code, out What3WordsError error);
+                _ = Enum.TryParse(Code, out What3WordsError error);
                 return error;
             }
         }

--- a/what3words.dotnet.wrapper/response/Response.cs
+++ b/what3words.dotnet.wrapper/response/Response.cs
@@ -1,42 +1,42 @@
-﻿namespace what3words.dotnet.wrapper.response
+﻿using Newtonsoft.Json;
+
+namespace what3words.dotnet.wrapper.response
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-    public class ApiException
-    {
-        public APIError Error { get; set; }
-    }
-
     public class APIResponse<T>
     {
+        public T Data { get; private set; }
+        [JsonProperty("error")]
+        public APIError Error { get; private set; }
+
         public APIResponse(T data)
         {
-            this.Data = data;
+            Data = data;
         }
 
         public APIResponse(APIError error)
         {
-            this.Error = error;
+            Error = error;
         }
 
-        public T Data { get; private set; }
-        public APIError Error { get; private set; }
-
-        public bool IsSuccessful { get { return Data != null; } }
+        public bool IsSuccessful => Data != null;
     }
 
     public class APIResponse
     {
+        [JsonProperty("error")]
+        public APIError Error { get; private set; }
+
         public APIResponse()
         {
         }
 
         public APIResponse(APIError error)
         {
-            this.Error = error;
+            Error = error;
         }
 
-        public APIError Error { get; private set; }
 
-        public bool IsSuccessful { get { return Error == null; } }
+        public bool IsSuccessful => Error == null;
     }
 }

--- a/what3words.dotnet.wrapper/what3words.dotnet.wrapper.csproj
+++ b/what3words.dotnet.wrapper/what3words.dotnet.wrapper.csproj
@@ -29,10 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Refit" Version="6.0.24" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="web_hi_res_512.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
@@ -41,6 +37,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/what3words.dotnet.wrapper/what3words.dotnet.wrapper.csproj
+++ b/what3words.dotnet.wrapper/what3words.dotnet.wrapper.csproj
@@ -5,7 +5,7 @@
     <Authors>What3words</Authors>
     <Product>What3words .NET Wrapper</Product>
     <PackageId>what3words.dotnet.wrapper</PackageId>
-    <PackageVersion>4.0.0</PackageVersion>
+    <PackageVersion>4.1.0</PackageVersion>
     <Description>A .NET library to use the what3words v3 API.
 
       API methods are grouped into a single service object which can be centrally managed by a
@@ -23,9 +23,9 @@
     <PackageProjectUrl>https://developer.what3words.com/public-api</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>4.0.0</Version>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
-    <FileVersion>4.0.0</FileVersion>
+    <Version>4.1.0</Version>
+    <AssemblyVersion>4.1.0</AssemblyVersion>
+    <FileVersion>4.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refit v6.0.24 has been [reported](https://github.com/what3words/w3w-dotnet-wrapper/issues/16) with vulnerabilities, we've been meaning to move away from Refit for a while now and this is a good chance to finally do that change and move over to just using the standard `HttpClient` class.

This should not change how the library works as Refit is just an internal dependency.